### PR TITLE
Restore persistent data generation for C

### DIFF
--- a/tvm_linker/src/main.rs
+++ b/tvm_linker/src/main.rs
@@ -103,6 +103,7 @@ fn linker_main() -> Result<(), String> {
             (@arg DEBUG: --debug "Prints debug info: xref table and parsed assembler sources")
             (@arg LIB: --lib +takes_value ... number_of_values(1) "Standard library source file. If not specified lib is loaded from environment variable TVM_LINKER_LIB_PATH if it exists.")
             (@arg OUT_FILE: -o +takes_value "Output file name")
+            (@arg LANGUAGE: --language +takes_value "Enable language-specific features in linkage")
         )
         (@subcommand test =>
             (about: "execute contract in test environment")
@@ -259,6 +260,7 @@ fn linker_main() -> Result<(), String> {
         };
 
         let debug = compile_matches.is_present("DEBUG");
+        prog.set_language(compile_matches.value_of("LANGUAGE"));
 
         if debug {
            prog.debug_print();

--- a/tvm_linker/src/testcall.rs
+++ b/tvm_linker/src/testcall.rs
@@ -378,11 +378,11 @@ pub fn call_contract_ex<F>(
         Err(exc) => match tvm_exception(exc) {
             Ok(exc) => {
                 println!("Unhandled exception: {}", exc);
-                exc.number as i32
+                exc.exception_or_custom_code()
             }
             _ => -1
         }
-        Ok(code) => code as i32
+        Ok(code) => code,
     };
     println!("TVM terminated with exit code {}", exit_code);
     println!("Gas used: {}", engine.get_gas().get_gas_used());


### PR DESCRIPTION
Introduce --language option to enable language-specific linkage
features and generate a dictionary of globals in c4 for C programs.