### PR TITLE
Add an option for setting workchain id

### DIFF
--- a/tvm_linker/src/main.rs
+++ b/tvm_linker/src/main.rs
@@ -121,6 +121,7 @@ fn linker_main() -> Result<(), String> {
             (@arg NOW: --now +takes_value "Supplies transaction creation unixtime")
             (@arg TICKTOCK: --ticktock +takes_value conflicts_with[BODY] "Emulates ticktock transaction in masterchain, 0 for tick and -1 for tock")
             (@arg GASLIMIT: -l --("gas-limit") +takes_value "Defines gas limit for tvm execution")
+            (@arg WC: -w +takes_value "Sets workchain id, -1 by default")
             (@arg INPUT: +required +takes_value "TVM assembler source file or contract name if used with test subcommand")
             (@arg ABI_JSON: -a --("abi-json") +takes_value conflicts_with[BODY] "Supplies json file with contract ABI")
             (@arg ABI_METHOD: -m --("abi-method") +takes_value conflicts_with[BODY] "Supplies the name of the calling contract method")
@@ -384,11 +385,15 @@ fn run_test_subcmd(matches: &ArgMatches) -> Result<(), String> {
         .map(|v| i64::from_str_radix(v, 10))
         .transpose()
         .map_err(|e| format!("cannot parse gas limit value: {}", e))?;
-    
+
+    let wid = matches.value_of("WC")
+        .map(|wc| i8::from_str_radix(wc, 10).unwrap());
+
     call_contract(
         matches.value_of("INPUT").unwrap(),
         matches.value_of("BALANCE"),
         msg_info,
+        wid,
         sign,
         ticktock,
         gas_limit,

--- a/tvm_linker/src/program.rs
+++ b/tvm_linker/src/program.rs
@@ -180,6 +180,7 @@ impl Program {
         let (exit_code, mut state_init) = call_contract_ex(
             AccountId::from(UInt256::default()),
             IntegerData::zero(),
+            None, // wid
             state_init,
             None, // debug_info
             None, // balance,

--- a/tvm_linker/src/testcall.rs
+++ b/tvm_linker/src/testcall.rs
@@ -239,6 +239,7 @@ pub fn call_contract<F>(
     smc_file: &str,
     smc_balance: Option<&str>,
     msg_info: MsgInfo,
+    wid: Option<i8>,
     key_file: Option<Option<&str>>,
     ticktock: Option<i8>,
     gas_limit: Option<i64>,
@@ -252,7 +253,7 @@ pub fn call_contract<F>(
     let state_init = load_from_file(&format!("{}.tvc", smc_file));
     let debug_info = load_debug_info(&state_init);
     let (exit_code, state_init) = call_contract_ex(
-        addr, addr_int, state_init, debug_info, smc_balance,
+        addr, addr_int, wid, state_init, debug_info, smc_balance,
         msg_info, key_file, ticktock, gas_limit, action_decoder, debug);
     if exit_code == 0 || exit_code == 1 {
         let smc_name = smc_file.to_owned() + ".tvc";
@@ -297,6 +298,7 @@ fn trace_callback(_engine: &Engine, info: &EngineTraceInfo, extended: bool, debu
 pub fn call_contract_ex<F>(
     addr: AccountId,
     addr_int: IntegerData,
+    wid: Option<i8>,
     state_init: StateInit,
     debug_info: Option<ContractDebugInfo>,
     smc_balance: Option<&str>,
@@ -325,7 +327,10 @@ pub fn call_contract_ex<F>(
     let mut state_init = state_init;
     let (code, data) = load_code_and_data(&state_init);
 
-    let workchain_id = if func_selector > -2 { 0 } else { -1 };
+    let workchain_id = match wid {
+        Some(id) => id,
+        None => -1,
+    };
     let (smc_value, smc_balance) = decode_balance(smc_balance).unwrap();
     let registers = initialize_registers(
         data,
@@ -430,6 +435,7 @@ pub fn perform_contract_call<F>(
             bounced: false,
             body: body
         },
+        None,
         key_file,
         ticktock,
         None,


### PR DESCRIPTION
Warning: this changes current default behavior.
Default is 0 currently (except for ticktock), but will be -1.