### PR TITLE
Unlocked debug mode

### DIFF
--- a/tvm_linker/src/debug_info.rs
+++ b/tvm_linker/src/debug_info.rs
@@ -29,21 +29,25 @@ impl DebugInfo {
 }
 
 
-pub fn save_debug_info(info: DebugInfo) {
+pub fn save_debug_info(
+    info: DebugInfo,
+    filename: String
+) {
     let s = serde_json::to_string_pretty(&info).unwrap();
-    let mut f = std::fs::File::create("./debug_info.json").unwrap();
+    let mut f = std::fs::File::create(filename).unwrap();
     write!(f, "{}", s).unwrap();
 }
 
 pub fn load_debug_info(
-    state_init: &StateInit
+    state_init: &StateInit,
+    filename: String
 ) -> Option<ContractDebugInfo> {
 
     // println!("---- load_debug_info ----");
 
     let mut hash2function = HashMap::new();
 
-    let debug_info_str = std::fs::read_to_string("./debug_info.json");
+    let debug_info_str = std::fs::read_to_string(filename);
     if debug_info_str.is_err() {
         return None;
     }
@@ -58,25 +62,34 @@ pub fn load_debug_info(
     for func in debug_info_json.internals.iter() {
         let id = &(func.id as i32);
         let key = id.clone().write_to_new_cell().unwrap().into();
-        let val = dict1.get(key).unwrap().unwrap();
-        let hash = val.cell().repr_hash();
-        hash2function.insert(hash, func.name.clone());
+        let val = dict1.get(key).unwrap();
+        if val.is_some() {
+            let val = val.unwrap();
+            let hash = val.cell().repr_hash();
+            hash2function.insert(hash, func.name.clone());
+        }
     }
     
     for func in debug_info_json.publics.iter() {
         let id = &(func.id as u32);
         let key = id.clone().write_to_new_cell().unwrap().into();
-        let val = dict1.get(key).unwrap().unwrap();
-        let hash = val.cell().repr_hash();
-        hash2function.insert(hash, func.name.clone());
+        let val = dict1.get(key).unwrap();
+        if val.is_some() {
+            let val = val.unwrap();
+            let hash = val.cell().repr_hash();
+            hash2function.insert(hash, func.name.clone());
+        }
     }
 
     for func in debug_info_json.privates.iter() {
         let id = &(func.id as u32);
         let key = id.clone().write_to_new_cell().unwrap().into();
-        let val = dict2.get(key).unwrap().unwrap();
-        let hash = val.cell().repr_hash();
-        hash2function.insert(hash, func.name.clone());
+        let val = dict2.get(key).unwrap();
+        if val.is_some() {
+            let val = val.unwrap();
+            let hash = val.cell().repr_hash();
+            hash2function.insert(hash, func.name.clone());
+        }
     }
 
     hash2function.insert(root_cell.repr_hash(), "selector".to_owned());

--- a/tvm_linker/src/main.rs
+++ b/tvm_linker/src/main.rs
@@ -275,9 +275,8 @@ fn linker_main() -> Result<(), String> {
             let msg = "ABI is mandatory when CTOR_PARAMS is specified.";
             return Err(msg.to_string());
         }
-        // TODO: temporarily disabled. Later take it from command line
-        let debug_info = false;
-        prog.compile_to_file_ex(wc, abi_file, ctor_params, out_file, debug, debug_info)?;
+
+        prog.compile_to_file_ex(wc, abi_file, ctor_params, out_file, debug, debug)?;
         return Ok(());
     }
 
@@ -364,10 +363,14 @@ fn run_test_subcmd(matches: &ArgMatches) -> Result<(), String> {
         }
     };
     
-    let _abi_contract = match matches.value_of("ABI_JSON") {
+    let abi_json = matches.value_of("ABI_JSON");
+
+    let _abi_contract = match abi_json {
         Some(abi_file) => Some(load_abi_contract(&load_abi_json_string(abi_file)?)?),
         None => None
     };
+
+    let debug_info_filename = format!("{}{}", abi_json.map_or("debug_info.", |a| a.trim_end_matches("abi.json")), "debug.json");
 
     println!("TEST STARTED");
     println!("body = {:?}", body);
@@ -394,6 +397,7 @@ fn run_test_subcmd(matches: &ArgMatches) -> Result<(), String> {
         gas_limit,
         if matches.is_present("DECODEC6") { Some(action_decoder) } else { None },
         matches.is_present("TRACE"),
+        debug_info_filename,
     );
 
     println!("TEST COMPLETED");

--- a/tvm_linker/src/program.rs
+++ b/tvm_linker/src/program.rs
@@ -100,7 +100,7 @@ impl Program {
             ).collect()
     }
     
-    fn save_debug_info(&self) {
+    fn save_debug_info(&self, filename: String) {
         let mut debug_info = DebugInfo::new();
         for pair in self.publics_filtered(false).iter() {
             let id = *pair.0;
@@ -117,7 +117,7 @@ impl Program {
             let name = self.engine.internal_name(id).unwrap();
             debug_info.internals.push(DebugInfoFunction{id: id as i64, name: name});
         }
-        save_debug_info(debug_info);
+        save_debug_info(debug_info, filename);
     }
 
     pub fn public_method_dict(&self, remove_ctor: bool) -> std::result::Result<Option<Cell>, String> {
@@ -149,7 +149,8 @@ impl Program {
             state_init = self.apply_constructor(state_init, abi_file.unwrap(), ctor_params, trace)?;
         }
         if debug_info {
-            self.save_debug_info();
+            let debug_info_filename = format!("{}{}", abi_file.map_or("debug_info.", |a| a.trim_end_matches("abi.json")), "debug.json");
+            self.save_debug_info(debug_info_filename);
         }
         save_to_file(state_init, out_file, wc)
     }
@@ -467,7 +468,8 @@ mod tests {
             None,
             Some(3000), // gas limit
             Some(|_, _| {}),
-            false
+            false,
+            String::from("")
         );
         // must equal to out of gas exception
         assert_eq!(exit_code, 13);

--- a/tvm_linker/src/testcall.rs
+++ b/tvm_linker/src/testcall.rs
@@ -244,13 +244,14 @@ pub fn call_contract<F>(
     gas_limit: Option<i64>,
     action_decoder: Option<F>,
     debug: bool,
+    debug_info_filename: String,
 ) -> i32
     where F: Fn(SliceData, bool)
 {
     let addr = AccountId::from_str(smc_file).unwrap();
     let addr_int = IntegerData::from_str_radix(smc_file, 16).unwrap();
     let state_init = load_from_file(&format!("{}.tvc", smc_file));
-    let debug_info = load_debug_info(&state_init);
+    let debug_info = load_debug_info(&state_init, debug_info_filename);
     let (exit_code, state_init) = call_contract_ex(
         addr, addr_int, state_init, debug_info, smc_balance,
         msg_info, key_file, ticktock, gas_limit, action_decoder, debug);
@@ -434,7 +435,8 @@ pub fn perform_contract_call<F>(
         ticktock,
         None,
         if decode_c5 { Some(action_decoder) } else { None },
-        debug
+        debug,
+        String::from("")
     )
 }
 


### PR DESCRIPTION
Now --debug flag for compile also generates debug info file which is used in test subcommand with --trace flag to log function name which is currently executed.