### PR TITLE
For the testcall, use capabilities from the config BOC file

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,13 @@ Use `--decode-c6` to see output actions in user-friendly format.
 
 Use `--balance <value>` to define account balance in nanograms. It will be available  at the bottom of initial stake and in SmartContractInfo tuple from c7 register .
 
+Use `--config <boc_file>` to define the config parameters to run VM with. The BOC file is a state of the config smart-contract of the Masterchain. 
+The capabilities field of the config defines the VM mode of operation. If the config parameter is omitted, the capabilities default value of 0x42E is used. 
+For the available capability codes consult [here](https://github.com/tonlabs/ton-labs-block/blob/8f39a1b467919d5fb3129800f07357883be82d77/src/config_params.rs#L336)
+
+Note: configuration smart-contract resides at the address: -1:5555555555555555555555555555555555555555555555555555555555555555
+
+
 Use `--internal` to send internal message to the contract with defined nanograms in `value`. By default, source address in internal message in zero address (`0000...0000`), to define another address use option `--src <address>`, where address should be in the format <wc>:<bytes32> (i.e. "0:1122...AABB"). 
 
 Account and message balance can have extended format with extra currencies: `{ "main": int, "extra": {"i": int, ...} }`.

--- a/src/testcall.rs
+++ b/src/testcall.rs
@@ -27,14 +27,14 @@ use ton_vm::error::tvm_exception;
 use ton_vm::stack::{StackItem, Stack, savelist::SaveList, integer::IntegerData};
 use ton_vm::SmartContractInfo;
 use ton_types::{AccountId, BuilderData, Cell, SliceData, Result, Status};
-use ton_block::{CurrencyCollection, Deserializable, ExternalInboundMessageHeader, GlobalCapabilities, Grams, InternalMessageHeader, Message, MsgAddressExt, MsgAddressInt, OutAction, OutActions, Serializable, StateInit, UnixTime32};
+use ton_block::{
+    CurrencyCollection, Deserializable, ExternalInboundMessageHeader, Grams,
+    InternalMessageHeader, Message, MsgAddressExt, MsgAddressInt, OutAction,
+    OutActions, Serializable, StateInit, UnixTime32
+};
 use ton_labs_assembler::DbgInfo;
 
 const DEFAULT_ACCOUNT_BALANCE: &str = "100000000000";
-const ALL_CAPABILITIES: u64 = 0x572e
-    | (GlobalCapabilities::CapDiff as u64)
-    | (GlobalCapabilities::CapStorageFeeToTvm as u64)
-    | (GlobalCapabilities::CapCopyleft as u64);
 
 fn create_external_inbound_msg(src: MsgAddressExt, dst: MsgAddressInt, body: Option<SliceData>) -> Message {
     let hdr = ExternalInboundMessageHeader {
@@ -91,10 +91,11 @@ fn sign_body(body: &mut SliceData, key_file: Option<&str>) -> Status {
     Ok(())
 }
 
-fn initialize_registers(data: SliceData, code: Cell, myself: MsgAddressInt, now: u32, balance: (u64, CurrencyCollection), config: Option<Cell>) -> Result<SaveList> {
+fn initialize_registers(data: SliceData, code: Cell, myself: MsgAddressInt, now: u32, balance: (u64, CurrencyCollection), config: Option<Cell>,
+                        capabilities: u64) -> Result<SaveList> {
     let mut ctrls = SaveList::new();
     let mut info = SmartContractInfo::with_myself(myself.serialize()?.into());
-    info.capabilities = ALL_CAPABILITIES;
+    info.capabilities = capabilities;
     info.balance.grams = ton_block::Grams::from(balance.0);
     info.balance.other = ton_block::ExtraCurrencyCollection::from(balance.1.other_as_hashmap());
     info.unix_time = now;
@@ -317,7 +318,8 @@ pub struct TestCallParams<'a, F: Fn(SliceData, bool)> {
     pub gas_limit: Option<i64>,
     pub action_decoder: Option<F>,
     pub trace_level: TraceLevel,
-    pub debug_info: Option<DbgInfo>
+    pub debug_info: Option<DbgInfo>,
+    pub capabilities: u64
 }
 
 pub fn call_contract<F>(
@@ -349,6 +351,7 @@ pub fn call_contract<F>(
         params.msg_info.now,
         (smc_value, smc_balance),
         params.config,
+        params.capabilities
     )?;
 
     let mut stack = Stack::new();
@@ -399,7 +402,7 @@ pub fn call_contract<F>(
     };
 
     let mut engine = Engine::with_capabilities(
-        ALL_CAPABILITIES
+        params.capabilities
     ).setup_with_libraries(
         code, Some(registers), Some(stack), Some(gas), vec![]
     );


### PR DESCRIPTION
For the testcall, use capabilities from the config BOC file. If none is provided, use the default value as in the main network.